### PR TITLE
Fix oh my zsh setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ alias l="marks"
 
 ```sh
 cd ~/.oh-my-zsh/custom/plugins
-git clone https://github.com/zpm-zsh/zshmarks.git
+git clone https://github.com/zpm-zsh/zshmarks.git bookmarks
 ```
 
 * Activate the plugin in `~/.zshrc`:


### PR DESCRIPTION
For Oh my zsh the directory name must be the same as the *.plugin.zsh file